### PR TITLE
(rigoberto)modifico package.json del front con *build: vite build*

### DIFF
--- a/Client/vite-project/package.json
+++ b/Client/vite-project/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite build",
+    "build": "vite build",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview"
   },


### PR DESCRIPTION
#126 
Tanto Render como Vercel, no permiten el deploy del lado cliente debido a que debe ir esta línea en el package.json.

En la sección "scripts",  se reemplaza el contenido de "build" por:

"scripts": {
"build": "vite build"
}
